### PR TITLE
Add Dockerfile

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,1 @@
+Dockerfile

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,38 @@
+FROM ubuntu:20.04 AS deps
+
+RUN apt update \
+  && export DEBIAN_FRONTEND=noninteractive \
+  && apt install -y --no-install-recommends \
+  libgmp-dev \
+  libmpfr-dev \
+  libgsl-dev \
+  python3-appdirs \
+  python3-matplotlib \
+  python3-pandas \
+  python3-pysam \
+  python3-scipy \
+  python3-setuptools \
+  python3-sklearn \
+  python3-tqdm \
+  && rm -rf /var/lib/apt/lists/*
+
+FROM deps AS builder
+
+RUN apt update \
+  && apt install -y --no-install-recommends \
+  ca-certificates \
+  cython3 \
+  g++ \
+  git \
+  python3-dev \
+  python3-setuptools-scm
+
+COPY ./ /src
+WORKDIR /src
+RUN python3 setup.py install
+
+FROM deps
+COPY --from=builder /usr/local/ /usr/local/
+WORKDIR /mnt
+
+ENTRYPOINT ["/usr/local/bin/smc++"]

--- a/README.rst
+++ b/README.rst
@@ -54,7 +54,8 @@ environment.
 
 You may also build the software
 from scratch using the `build instructions`_ provided in the next
-section.
+section, or create a Docker image following the `Docker instructions`_
+in the subsequent section.
 
 .. _releases page: https://github.com/popgenmethods/smcpp/releases/latest
 .. _Anaconda: https://www.continuum.io/downloads
@@ -116,6 +117,18 @@ environment::
 Then, install SMC++ as described above.
 
 .. _virtual environment: http://docs.python-guide.org/en/latest/dev/virtualenvs/
+
+Docker instructions
+==================
+
+As an alternative to the Anaconda package and building from scratch in
+the host environment, a Docker image for smc++ can be built:
+
+    docker build -t smcpp .
+
+Subsequently, smc++ can be run in a container:
+
+    docker run --rm -v $PWD:/mnt smcpp [ARGUMENTS]
 
 Usage
 =====


### PR DESCRIPTION
A user on our HPC cluster attempted to install smcpp via conda package, and encountered the `GLIBC_2.29 not found` error described in https://github.com/popgenmethods/smcpp/issues/136#issuecomment-594748655 and mentioned [in the FAQ](https://github.com/popgenmethods/smcpp#frequently-asked-questions). This is substantially newer than the glibc 2.17 installed on CentOS 7.x. Since the build process can be involved for some users, I created a Docker image & exported it to a Singularity image using [docker2singularity](https://github.com/singularityhub/docker2singularity) for use in the multi-tenant HPC cluster environment.

This PR includes a Dockerfile that was sketched out for this purpose, and a brief section in the README on how to build a Docker image from it & create/run a container. A Docker option could be useful for other users who would like to run smcpp, but don't have the right glibc version as required by the conda package, and don't have the time/experience to install all dependencies (an automated build on DockerHub, allowing users to pull an image instead of building it, could be even more efficient). It might also facilitate CI testing, etc.