### PR TITLE
Add numpy as a build requirement

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 # pyproject.toml
 [build-system]
-requires = ["setuptools>=45", "wheel", "setuptools_scm>=6.2"]
+requires = ["setuptools>=45", "wheel", "setuptools_scm>=6.2", "oldest-supported-numpy"]
 
 [tool.setuptools_scm]
 write_to = "smcpp/_version.py"


### PR DESCRIPTION
Without this, numpy cannot be found when building with `pip install .`
or the `build` package.

```
$ python -m venv venv
$ source venv/bin/activate
(venv) $ pip install --upgrade pip build
...
(venv) $ python -m build
* Creating venv isolated environment...
* Installing packages in isolated environment... (setuptools>=45, setuptools_scm>=6.2, wheel)
* Getting dependencies for sdist...
Traceback (most recent call last):
  File "/home/grg/src/smcpp/venv/lib/python3.10/site-packages/pep517/in_process/_in_process.py", line 363, in <module>
    main()
  File "/home/grg/src/smcpp/venv/lib/python3.10/site-packages/pep517/in_process/_in_process.py", line 345, in main
    json_out['return_val'] = hook(**hook_input['kwargs'])
  File "/home/grg/src/smcpp/venv/lib/python3.10/site-packages/pep517/in_process/_in_process.py", line 297, in get_requires_for_build_sdist
    return hook(config_settings)
  File "/tmp/build-env-uyngr83_/lib/python3.10/site-packages/setuptools/build_meta.py", line 181, in get_requires_for_build_sdist
    return self._get_build_requires(config_settings, requirements=[])
  File "/tmp/build-env-uyngr83_/lib/python3.10/site-packages/setuptools/build_meta.py", line 159, in _get_build_requires
    self.run_setup()
  File "/tmp/build-env-uyngr83_/lib/python3.10/site-packages/setuptools/build_meta.py", line 281, in run_setup
    super(_BuildMetaLegacyBackend,
  File "/tmp/build-env-uyngr83_/lib/python3.10/site-packages/setuptools/build_meta.py", line 174, in run_setup
    exec(compile(code, __file__, 'exec'), locals())
  File "setup.py", line 11, in <module>
    import numpy as np
ModuleNotFoundError: No module named 'numpy'

ERROR Backend subprocess exited when trying to invoke get_requires_for_build_sdist
```