### PR TITLE
Install libbz2-dev and liblzma-dev in the Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,7 @@ RUN apt update \
   libmpfr-dev \
   libgsl-dev \
   libbz2-dev \
+  liblzma-dev \
   python3-appdirs \
   python3-matplotlib \
   python3-pandas \

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,7 @@ RUN apt update \
   libgmp-dev \
   libmpfr-dev \
   libgsl-dev \
+  libbz2-dev \
   python3-appdirs \
   python3-matplotlib \
   python3-pandas \

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,9 @@ RUN apt update \
   libgsl-dev \
   libbz2-dev \
   liblzma-dev \
+  libcurl4-openssl-dev \
+  libssl-dev \
+  make \
   python3-appdirs \
   python3-matplotlib \
   python3-pandas \


### PR DESCRIPTION
Without those the build (`docker build -t smcpp:latest .`) fails with errors like:

```
...
checking for lzma_easy_buffer_encode in -llzma... no
configure: error: liblzma development files not found

The CRAM format may use LZMA2 compression, which is implemented in HTSlib
by using compression routines from liblzma <http://tukaani.org/xz/>.

Building HTSlib requires liblzma development files to be installed on the
build machine; you may need to ensure a package such as liblzma-dev (on Debian
or Ubuntu Linux), xz-devel (on RPM-based Linux distributions or Cygwin), or
xz (via Homebrew on macOS) is installed; or build XZ Utils from source.

Either configure with --disable-lzma (which will make some CRAM files
produced elsewhere unreadable) or resolve this error to build HTSlib.
error: [Errno 2] No such file or directory: 'make'
# pysam: htslib configure options: None
The command '/bin/sh -c python3 setup.py install' returned a non-zero code: 1
```

If the changes are accepted then maybe the extra dependencies should be added to the [README](https://github.com/popgenmethods/smcpp/blob/fdde7c3df6c90d3b01fd51ebfbf52da3898b48fc/README.rst?plain=1#L75) too ?!