### PR TITLE
Replace usage of set-output with $GITHUB_OUTPUT

### DIFF
--- a/.github/workflows/docker-push.yml
+++ b/.github/workflows/docker-push.yml
@@ -29,7 +29,7 @@ jobs:
 
       - name: Set variables
         id: vars
-        run: echo "::set-output name=date_tag::$(date +%y%m%d-%H%M)"
+        run: echo "date_tag=$(date +%y%m%d-%H%M)" >> $GITHUB_OUTPUT
 
       - name: Docker Buildx Create
         run: docker buildx create --use


### PR DESCRIPTION
https://github.com/popgenmethods/smcpp/actions/runs/3323408369 prints a warning about it.

https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/ gives more details about the new way and the deprecation period